### PR TITLE
Fix video grabber not working with some links

### DIFF
--- a/watch-dl.py
+++ b/watch-dl.py
@@ -1,3 +1,5 @@
+#! /usr/bin/python
+
 # -*- coding: utf-8 -*-
 import urllib
 import re
@@ -18,7 +20,7 @@ def info_extractor(url):
         webpage = urllib2.urlopen(request).read()
     
         print "[watchcartoononline-dl]  Finding video"
-        video_url = re.search(r'<iframe id="(.+?)0" (.+?)>', webpage).group()
+        video_url = re.search(r'<iframe src="http://www.watchcartoononline.com/inc/(.+?)>', webpage).group()
         video_url = re.search('src="(.+?)"', video_url).group(1).replace(' ','%20')
         
         # "clicks" the "Click Here to Watch Free" button to so it can access the actual video file url


### PR DESCRIPTION
Some watchcartoononline links don't have an id in their video iframe, so find the video iframe from the src link which always seems to start with http://www.watchcartoononline.com/inc/